### PR TITLE
:bookmark: bump version 0.4.0 -> 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.5.0]
+
 ### Added
 
 - Support for HTTP and SSE transport protocols via CLI arguments (`--transport`, `--host`, `--port`, `--path`)
@@ -74,9 +76,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/mcp-django-shell/compare/v0.4.0...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/mcp-django-shell/compare/v0.5.0...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/mcp-django-shell/releases/tag/v0.1.0
 [0.2.0]: https://github.com/joshuadavidthomas/mcp-django-shell/releases/tag/v0.2.0
 [0.3.0]: https://github.com/joshuadavidthomas/mcp-django-shell/releases/tag/v0.3.0
 [0.3.1]: https://github.com/joshuadavidthomas/mcp-django-shell/releases/tag/v0.3.1
 [0.4.0]: https://github.com/joshuadavidthomas/mcp-django-shell/releases/tag/v0.4.0
+[0.5.0]: https://github.com/joshuadavidthomas/mcp-django-shell/releases/tag/v0.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
 description = "MCP server providing a stateful Django shell for AI assistants."
 name = "mcp-django-shell"
 readme = "README.md"
-version = "0.4.0"
+version = "0.5.0"
 requires-python = ">=3.10"
 
 [project.urls]
@@ -82,7 +82,7 @@ Source = "https://github.com/joshuadavidthomas/mcp-django-shell"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.4.0"
+current_version = "0.5.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"


### PR DESCRIPTION
- `f56672a`: Add HTTP and SSE transport support to CLI (#15)