### PR TITLE
:bookmark: bump version 0.7.0 -> 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.8.0]
+
 ### Added
 
 - Optional `imports` parameter to `django_shell` tool for providing import statements separately from main code execution.
@@ -106,7 +108,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/mcp-django-shell/compare/v0.7.0...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/mcp-django-shell/compare/v0.8.0...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/mcp-django-shell/releases/tag/v0.1.0
 [0.2.0]: https://github.com/joshuadavidthomas/mcp-django-shell/releases/tag/v0.2.0
 [0.3.0]: https://github.com/joshuadavidthomas/mcp-django-shell/releases/tag/v0.3.0
@@ -115,3 +117,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.5.0]: https://github.com/joshuadavidthomas/mcp-django-shell/releases/tag/v0.5.0
 [0.6.0]: https://github.com/joshuadavidthomas/mcp-django-shell/releases/tag/v0.6.0
 [0.7.0]: https://github.com/joshuadavidthomas/mcp-django-shell/releases/tag/v0.7.0
+[0.8.0]: https://github.com/joshuadavidthomas/mcp-django-shell/releases/tag/v0.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
 description = "MCP server providing a stateful Django shell for LLM assistants."
 name = "mcp-django-shell"
 readme = "README.md"
-version = "0.7.0"
+version = "0.8.0"
 requires-python = ">=3.10"
 
 [project.urls]
@@ -83,7 +83,7 @@ Source = "https://github.com/joshuadavidthomas/mcp-django-shell"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.7.0"
+current_version = "0.8.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"


### PR DESCRIPTION
- `b1065aa`: update wording to be clearer about AI vs LLM distinction (#26)
- `e4c2989`: update wording to be clearer about AI vs LLM distinction (#26)
- `6f53284`: Add imports parameter to django_shell tool and refactor code parsing (#27)